### PR TITLE
Improved check for string argument to prStrWidth

### DIFF
--- a/Reuse.pm
+++ b/Reuse.pm
@@ -1260,8 +1260,14 @@ sub prStrWidth
    my $FontSize = shift || $fontSize;
    my $w = 0;
 
-   #FIXME: We need to have more robust error trapping and communication of that back to the caller
-   return unless $string; # there's no use continuing if no string is passed in
+   # there's no use continuing if no string is passed in
+   if (! defined($string))
+   {  errLog("undefined value passed to prStrWidth");
+   }
+
+   if (length($string) == 0)
+   {  return 0;
+   }
 
    if(my($width) = ttfStrWidth($string, $Font, $FontSize))
    {  return $width;


### PR DESCRIPTION
Commit 11ecd4a893fdfcf28c14be7a8bff133f17a059b1 added a check to ensure a text string argument was passed to the prStrWidth function.  Unfortunately it introduced a subtle bug - if a string was provided, but it contained something that evaluated to false in a boolean context (e.g.: '0') then the function would return undef.

The commit also added a comment suggesting better error handling was required.

This commit adds an improved argument check and makes use of the module's existing errLog error handling routine.

If the $string value supplied is undef, the function will now die with a suitable error message via errLog.
If $string is an empty string, then a value of 0 is returned (rather than undef) since this seems both accurate and benign.