### PR TITLE
Fix file descriptor leak in TrueType font handling

### DIFF
--- a/Reuse.pm
+++ b/Reuse.pm
@@ -1516,6 +1516,17 @@ sub text_width
    return $self->{ttfont}->width($text) * $size;
 }
 
+sub DESTROY
+{  my $self = shift;
+   if(my $ttfont = $self->{ttfont})
+   {  if(my $font = delete $ttfont->{' font'})
+      { $font->release();
+      }
+      $ttfont->release();
+   }
+   %$self = ();
+}
+
 
 package PDF::Reuse;  # Applies to the autoloaded methods below (?)
 


### PR DESCRIPTION
- TrueType font files are being opened but never closed, so a long-running
  process would leak one file descriptor for each font file per PDF file
  produced
- the PDF::Reuse::TTFont provides a wrapper around Text::PDF::TTFont
  which in turn wraps Font::TTF
- the PDF::Reuse code should have been calling the 'release()' method on
  the wrapped font object to enable resources to be freed
- this commit adds a destructor which calls release on the
  Text::PDF::TTFont object, and also on its Font::TTF object
- without the step to manually free the Font::TTF object, file descriptors
  were still being leaked about 50% of the time