### PR TITLE
Fix error Can't use 'defined(%hash)'

### DIFF
--- a/Reuse.pm
+++ b/Reuse.pm
@@ -3730,7 +3730,7 @@ sub prDocForm
   if (($effect eq 'print') && ($form{$fSource}[fVALID]) && ($refNr))
   {   if ((! defined $interActive)
       && ($sidnr == 1)
-      &&  (defined %{$intAct{$fSource}[0]}) )
+      &&  (%{$intAct{$fSource}[0]}) )
       {  $interActive = $infil . ' ' . $sidnr;
          $interAktivSida = 1;
       }


### PR DESCRIPTION
Fix error
Can't use 'defined(%hash)' (Maybe you should just omit the defined()?)

Omit the defined
