### PR TITLE
CI: re-enable Windows and macOS with per-platform isolation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,14 @@
 version: 2
 updates:
 
-  # Upstream workflow refs are pinned to a SHA so CI cannot change without a
-  # commit here. Dependabot proposes the bumps, keeping the pins current
-  # without giving up reproducibility.
+  # Covers actions/* and other tagged refs that appear in workflows here.
+  #
+  # It does NOT maintain the PerlToolsTeam/github_workflows SHA pins in
+  # ci.yml. Dependabot only advances a SHA-pinned ref when the upstream repo
+  # publishes tags (dependabot-core github_actions/update_checker.rb,
+  # latest_commit_sha returns early without a latest_version_tag), and that
+  # repo has none. Those pins must be reviewed by hand -- see
+  # docs/ci-pin-maintenance.md.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+
+  # Upstream workflow refs are pinned to a SHA so CI cannot change without a
+  # commit here. Dependabot proposes the bumps, keeping the pins current
+  # without giving up reproducibility.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,23 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Calls the cpan-test composite action directly rather than the cpan-test.yml
+  # reusable workflow: the latter fixes its own matrix strategy at the default
+  # fail-fast: true, which cancels healthy cells when an unrelated one fails and
+  # makes per-platform results unreadable.
   test:
-    uses: PerlToolsTeam/github_workflows/.github/workflows/cpan-test.yml@main
-    with:
-      os: '["ubuntu-latest"]'
-      perl_version: '["5.24", "5.30", "5.36", "5.40"]'
+    runs-on: ${{ matrix.os }}
+    name: Perl ${{ matrix.perl }} on ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        perl: [ "5.24", "5.30", "5.36", "5.40" ]
+    steps:
+      - uses: PerlToolsTeam/github_workflows/.github/actions/cpan-test@main
+        with:
+          perl_version: ${{ matrix.perl }}
+          os: ${{ matrix.os }}
 
   coverage:
     uses: PerlToolsTeam/github_workflows/.github/workflows/cpan-coverage.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,15 @@ jobs:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         perl: [ "5.24", "5.30", "5.36", "5.40" ]
     steps:
-      - uses: PerlToolsTeam/github_workflows/.github/actions/cpan-test@main
+      - uses: PerlToolsTeam/github_workflows/.github/actions/cpan-test@b4ba4e5553820e802da91d58eba295575945ad95 # main @ 2026-06-23
         with:
           perl_version: ${{ matrix.perl }}
           os: ${{ matrix.os }}
 
   coverage:
-    uses: PerlToolsTeam/github_workflows/.github/workflows/cpan-coverage.yml@main
+    uses: PerlToolsTeam/github_workflows/.github/workflows/cpan-coverage.yml@b4ba4e5553820e802da91d58eba295575945ad95 # main @ 2026-06-23
 
   perlcritic:
-    uses: PerlToolsTeam/github_workflows/.github/workflows/cpan-perlcritic.yml@main
+    uses: PerlToolsTeam/github_workflows/.github/workflows/cpan-perlcritic.yml@b4ba4e5553820e802da91d58eba295575945ad95 # main @ 2026-06-23
     with:
       level: 5

--- a/docs/ci-pin-maintenance.md
+++ b/docs/ci-pin-maintenance.md
@@ -1,0 +1,63 @@
+# CI pin maintenance
+
+`.github/workflows/ci.yml` pins every `PerlToolsTeam/github_workflows`
+reference to a commit SHA rather than `@main`.
+
+## Why pinned
+
+Tracking `@main` meant upstream could change this repository's CI with no
+commit here. That is not hypothetical: PDF-Reuse lost Windows CI for six
+months to an upstream regression, and the eventual fix arrived the same way.
+Neither event produced a commit in any of these repositories, and both were
+found only by re-measuring months later.
+
+## Why this needs a human
+
+**Dependabot does not maintain these pins.** It advances a SHA-pinned GitHub
+Actions ref only when the upstream repository publishes tags — see
+`github_actions/lib/dependabot/github_actions/update_checker.rb` in
+dependabot-core, where `latest_commit_sha` returns early unless
+`latest_version_tag` is present. `PerlToolsTeam/github_workflows` has no
+tags, so no update PR is ever opened for these refs.
+
+The `.github/dependabot.yml` in this repo is still useful — it covers tagged
+`actions/*` refs — but it is inert for the pins below.
+
+## What the pin does and does not freeze
+
+Frozen: the `PerlToolsTeam/github_workflows` files themselves (the composite
+action and the reusable workflows).
+
+Not frozen:
+
+- Actions invoked *inside* the pinned upstream files, which use tag refs
+  (`actions/checkout@v5`, `shogo82148/actions-setup-perl@v1`,
+  `ilammy/msvc-dev-cmd@v1`, `actions/upload-artifact@v5`). Tags can move.
+- Container images in the coverage and perlcritic workflows
+  (`davorg/perl-coveralls:latest`, `davorg/perl-perlcritic`), which float.
+
+So the pin is a boundary around one upstream repository, not a full CI lock.
+It removes the failure mode that actually bit us; it does not make CI
+bit-for-bit reproducible.
+
+## How to review the pin
+
+Roughly quarterly, or when CI behaves unexpectedly:
+
+    gh api repos/PerlToolsTeam/github_workflows/commits/main \
+      --jq '"\(.sha)  \(.commit.author.date)  \(.commit.message|split("\n")[0])"'
+
+Compare against the SHA in `ci.yml`. To see what changed since the pin:
+
+    gh api "repos/PerlToolsTeam/github_workflows/commits?sha=main&since=<pin-date>" \
+      --jq '.[] | "\(.commit.author.date)  \(.sha[0:8])  \(.commit.message|split("\n")[0])"'
+
+To advance: update all three refs in `ci.yml` plus the trailing
+`# main @ <date>` comments, push to a branch, and let the PR's own CI run be
+the verification. Do not advance a pin without a green run — the point of the
+pin is that upstream changes arrive as a reviewable event rather than a
+surprise.
+
+Keep the same SHA across all five distributions (PDF-Reuse, PDF-Reuse-Barcode,
+PDF-Reuse-OverlayChart, PDF-Reuse-Tutorial, Business-US-USPS-IMB) so a
+divergence between them is always a signal rather than noise.

--- a/docs/ci-pin-maintenance.md
+++ b/docs/ci-pin-maintenance.md
@@ -30,9 +30,11 @@ action and the reusable workflows).
 
 Not frozen:
 
-- Actions invoked *inside* the pinned upstream files, which use tag refs
-  (`actions/checkout@v5`, `shogo82148/actions-setup-perl@v1`,
-  `ilammy/msvc-dev-cmd@v1`, `actions/upload-artifact@v5`). Tags can move.
+- Actions invoked *inside* the pinned upstream files, which use tag refs.
+  In the composite action: `actions/checkout@v5`,
+  `shogo82148/actions-setup-perl@v1`, `ilammy/msvc-dev-cmd@v1`,
+  `actions/upload-artifact@v5`. In the coverage and perlcritic reusable
+  workflows: `actions/checkout@v7`. Tags can move.
 - Container images in the coverage and perlcritic workflows
   (`davorg/perl-coveralls:latest`, `davorg/perl-perlcritic`), which float.
 

--- a/docs/reviews/pr-25-round-1-codex.md
+++ b/docs/reviews/pr-25-round-1-codex.md
@@ -1,0 +1,44 @@
+# Review: PR #25 CI re-enable Windows and macOS
+
+Date: 2026-07-28
+Reviewed: `.github/workflows/ci.yml`, PR #25, upstream `PerlToolsTeam/github_workflows` reusable workflow and composite action at `main` (`b4ba4e5553820e802da91d58eba295575945ad95`), PR run `30388392273`, at commit `bfe2a4f8792a713a27571c47a55efce289afc956`
+Round: 1
+Label applied: `approved-by-codex-agent`
+
+## What Is Correct
+
+The direct composite-action call is behaviorally equivalent to the reusable workflow for the tested path. The upstream reusable workflow only defines `workflow_call` inputs, builds the `os`/`perl` matrix from JSON, leaves `strategy.fail-fast` at GitHub's default, names the job, and then calls `PerlToolsTeam/github_workflows/.github/actions/cpan-test@main` with `perl_version`, `os`, and `testing_context`. The PR keeps the same action and same effective default `testing_context`, while adding the one thing the reusable workflow cannot expose: `fail-fast: false`.
+
+Passing `os: ${{ matrix.os }}` is correct for the current upstream action. The action's conditionals use `startsWith(inputs.os, 'windows')`; the matrix value `windows-latest` matches that expectation, while `ubuntu-latest` and `macos-latest` correctly take the Unix branch.
+
+Dropping an explicit `testing_context` does not change the effective behavior. The reusable workflow default is `'[ ]'`, and the composite action default is also `'[ ]'`.
+
+The PR run is the right verification for this change. Run `30388392273` at commit `bfe2a4f8792a713a27571c47a55efce289afc956` passed all 12 `test` cells, plus `coverage` and `perlcritic`.
+
+## Blockers
+
+None.
+
+## What Needs Attention
+
+The green Windows run justifies saying the Windows failure is fixed upstream or no longer reproducible in the current upstream CI/toolchain path. It does not, by itself, prove which upstream commit fixed it. The PR body cites plausible matching `PerlToolsTeam/github_workflows` changes, but without bisecting or pin-testing the old/new upstream revisions, the exact-fix attribution remains an inference. That is acceptable for this CI re-enablement PR, but issue-closing language should avoid claiming more precision than was verified.
+
+Calling the composite action directly is a small maintainability tradeoff. The reusable workflow is the public wrapper; the composite action is one layer lower and may be treated by upstream as a less stable interface. The comment in `.github/workflows/ci.yml` explains why the bypass exists, and current behavior is sound, so this is not a blocker. If upstream later adds a `fail_fast` input to `cpan-test.yml`, returning to the reusable workflow would reduce that coupling.
+
+One inherited diagnostic weakness remains: the composite action names failure artifacts with `${{ github.run_id }}-${{ github.job }}`. In a matrix job, `${{ github.job }}` is the stable job id (`test` here), not the visible matrix name, so multiple failing cells in the same run may collide on artifact names. This is an upstream action issue already present through the reusable workflow, not a regression introduced by this PR.
+
+## Bloat / Non-Functional
+
+None. The workflow change is small and directly tied to the requirement to restore the full OS matrix while disabling fail-fast.
+
+## Recommendations
+
+Keep the workflow change as written.
+
+When closing #9, phrase the conclusion as "verified fixed/no longer reproducible on the current upstream workflow path" unless someone bisects the upstream action history. The evidence supports re-enabling Windows; it does not require proving the exact upstream commit.
+
+Consider opening an upstream issue or PR for matrix-unique artifact names in `PerlToolsTeam/github_workflows/.github/actions/cpan-test`, especially now that `fail-fast: false` can expose multiple simultaneous failures.
+
+## Bottom Line
+
+Approve. The direct composite-action call is a justified workaround for the reusable workflow's fixed `fail-fast` behavior, the inputs line up with the upstream action, default `testing_context` is preserved, and the full 12-cell CI run is the relevant verification. The remaining concerns are maintainability and diagnostic precision, not merge blockers.

--- a/docs/reviews/pr-25-round-2-codex.md
+++ b/docs/reviews/pr-25-round-2-codex.md
@@ -1,0 +1,40 @@
+# Review: PR #25 CI SHA pins and Dependabot
+
+Date: 2026-07-28
+Reviewed: PR #25 as a whole, with focus on `.github/dependabot.yml` and the second commit `3b9a72bf7d637826971ab6309348029664d68b04`
+Round: 2
+Label applied: `changes-requested`
+
+## What Is Correct
+
+The first commit's matrix change still looks sound. The direct call to the `cpan-test` composite action is the only way this PR gets `strategy.fail-fast: false`, and the current head run passed all 12 matrix cells plus coverage and perlcritic.
+
+`directory: "/"` is the right Dependabot location for workflow scanning. Dependabot-core special-cases `/` to scan `.github/workflows/` ([file_fetcher.rb](https://github.com/dependabot/dependabot-core/blob/main/github_actions/lib/dependabot/github_actions/file_fetcher.rb#L67-L84)), and its parser explicitly recognizes reusable workflow paths under `.github/workflows/*.yml` ([file_parser.rb](https://github.com/dependabot/dependabot-core/blob/main/github_actions/lib/dependabot/github_actions/file_parser.rb#L106-L111)). GitHub's docs also state that Dependabot can keep both actions and reusable workflows up to date.
+
+Pinning `PerlToolsTeam/github_workflows` to the measured-good commit is a real improvement over `@main` for the direct upstream workflow/action source. It prevents a future change in that repository from silently changing this repository's CI behavior.
+
+## Blockers
+
+The Dependabot maintenance claim is not reliable for these pins. `.github/dependabot.yml:4` says Dependabot keeps the SHA pins current, but all three refs in `.github/workflows/ci.yml:24`, `.github/workflows/ci.yml:30`, and `.github/workflows/ci.yml:33` point to path-based dependencies in `PerlToolsTeam/github_workflows`, and that upstream repository has no tags. Current Dependabot-core first looks for a latest tag before returning a replacement commit for a SHA-pinned GitHub Actions dependency ([update_checker.rb](https://github.com/dependabot/dependabot-core/blob/main/github_actions/lib/dependabot/github_actions/update_checker.rb#L157-L167)); if there is no tag, it returns no update. A current upstream issue reproduces the same failure shape for an untagged SHA-pinned path-based action: Dependabot opens no PR ([dependabot-core#15577](https://github.com/dependabot/dependabot-core/issues/15577)). Because `PerlToolsTeam/github_workflows` has zero tags, the added Dependabot config is likely inert for the exact dependency form this PR introduces. That defeats the stated "pin but keep current" rationale.
+
+## What Needs Attention
+
+The inline `# main @ 2026-06-23` comments will not be maintained in the way the PR implies. GitHub documents same-line comment updates for action version documentation, and Dependabot-core only rewrites a comment when it can match a previous semver tag for the old SHA and a new semver tag for the new SHA ([file_updater.rb](https://github.com/dependabot/dependabot-core/blob/main/github_actions/lib/dependabot/github_actions/file_updater.rb#L71-L115)). These comments are custom branch/date notes, and the upstream repository has no tags, so they would either remain unchanged if a SHA rewrite somehow happened or be ignored because no rewrite is produced. That makes them easy to turn into stale misinformation.
+
+Pinning `cpan-coverage.yml` and `cpan-perlcritic.yml` does not make those jobs reproducible end-to-end. The pinned workflows currently run `davorg/perl-coveralls:latest` and `davorg/perl-perlcritic` containers, and Dependabot-core does not update Docker container action references in GitHub Actions workflows. The pin still freezes the workflow file itself, but the container image behind the job can drift independently of this repo. The PR/commit rationale should narrow the claim, or the upstream workflows should pin image digests if true reproducibility is the requirement.
+
+The composite action pin freezes the action file at `b4ba4e55`, but not every action it invokes. At that commit the composite action still uses `actions/checkout@v5`, `shogo82148/actions-setup-perl@v1`, `ilammy/msvc-dev-cmd@v1`, and `actions/upload-artifact@v5`. Those refs remain tag-based and can move if their maintainers move tags. That is not a regression from `@main`, but it means the pin is a boundary around `PerlToolsTeam/github_workflows`, not a full CI dependency lock.
+
+## Bloat / Non-Functional
+
+None. The change is small. The issue is not over-engineering; it is that the automation chosen to avoid stale pins likely does not operate on this untagged upstream dependency.
+
+## Recommendations
+
+Do not merge the second commit as-is. Pick one of these before approval: have `PerlToolsTeam/github_workflows` publish semver tags and pin to tag-associated SHAs so Dependabot can advance them; replace Dependabot with a tool/workflow proven to update untagged path-based SHA refs; or keep the SHA pins but remove the "Dependabot keeps these current" claim and accept/manual-document that the pins must be audited periodically.
+
+If the intended guarantee is only "freeze the shared workflow repo, not every transitive CI input," say that explicitly in the commit/PR rationale. If the intended guarantee is stronger reproducibility, also address the Docker `latest` containers and tag-based actions inside the pinned upstream files.
+
+## Bottom Line
+
+Request changes. The first commit remains approvable, but the unreviewed second commit adds a maintenance mechanism that likely does not update the newly pinned untagged path-based refs. That leaves these five repositories with silently rotting CI pins while the comments imply automated freshness.

--- a/docs/reviews/pr-25-round-3-codex.md
+++ b/docs/reviews/pr-25-round-3-codex.md
@@ -1,0 +1,76 @@
+# Review: PR #25 CI SHA pins and Dependabot
+
+Date: 2026-07-28
+Reviewed: PR #25 as a whole at `950394ae896e6fe967f821f0956ba0e8d7190e1e`, with focus on the round-3 correction in `.github/dependabot.yml` and `docs/ci-pin-maintenance.md`
+Round: 3
+Label applied: `approved-by-codex-agent`
+
+## What Is Correct
+
+The round-2 blocker is resolved. `.github/dependabot.yml` no longer claims
+Dependabot will maintain the `PerlToolsTeam/github_workflows` SHA pins. The
+replacement text is accurate: Dependabot can still scan GitHub Actions
+dependencies in this repository, but the untagged path-based SHA pins in
+`.github/workflows/ci.yml` require manual review.
+
+I rechecked the relevant Dependabot behavior against the current
+dependabot-core source. `github_actions/lib/dependabot/github_actions/update_checker.rb`
+still has `latest_commit_sha` return early unless `latest_version_tag` exists,
+and `PerlToolsTeam/github_workflows` currently has zero tags. That matches the
+new comment and the maintenance doc.
+
+Keeping Dependabot enabled is sensible rather than misleading. It remains able
+to cover tagged GitHub Actions refs that appear directly in this repository's
+workflows, while the comment explicitly excludes the pinned
+`PerlToolsTeam/github_workflows` refs.
+
+`docs/ci-pin-maintenance.md` now documents the important operational boundary:
+the pin freezes the selected upstream repository files, not the tag-based
+actions and container images those pinned files invoke. It also gives a
+practical manual audit path and explicitly requires a green CI run before
+advancing the shared pin.
+
+The PR-wide workflow change still looks correct. The test job calls the pinned
+`cpan-test` composite action directly so this repository can own
+`strategy.fail-fast: false`, and the current PR head reports all CI cells green:
+12 test matrix jobs plus coverage and perlcritic, with macOS and Windows cells
+included.
+
+## Blockers
+
+None.
+
+## What Needs Attention
+
+The maintenance doc's "Not frozen" examples omit the two `actions/checkout@v7`
+refs used by the pinned coverage and perlcritic workflows. The surrounding
+statement is already correct because it says actions invoked inside the pinned
+upstream files can drift, so this is not blocking, but adding `actions/checkout@v7`
+to the example list would make the inventory complete.
+
+The quarterly cadence is a human process, not an enforced control. That is an
+acceptable tradeoff here because the PR now says so plainly, but whoever owns
+these distributions should put the cadence somewhere actionable outside this
+repository if they want it to happen reliably.
+
+## Bloat / Non-Functional
+
+None. The added maintenance documentation is proportionate to the operational
+burden introduced by SHA-pinning an untagged third-party workflow repository.
+
+## Recommendations
+
+Optionally add `actions/checkout@v7` to the "Not frozen" example list in
+`docs/ci-pin-maintenance.md` in a follow-up cleanup.
+
+Keep the cross-repository SHA consistency rule. I verified the documented
+`gh api` commands execute as written against `PerlToolsTeam/github_workflows`;
+because upstream `main` is still the pinned `b4ba4e55` commit dated
+2026-06-23, the "commits since" command currently returns no rows, which is the
+expected result.
+
+## Bottom Line
+
+Approve. The false Dependabot-maintenance claim has been removed, the new docs
+accurately explain both the manual upkeep requirement and the limits of the
+pin, and the current CI evidence supports the workflow change.


### PR DESCRIPTION
Restores the full three-OS test matrix dropped in 6655b8a ("Restrict CI to Linux-only for now"), and makes each matrix cell report independently.

Ref #9
Ref #10

## What changed

`.github/workflows/ci.yml` — the `test` job now calls the `cpan-test` **composite action** directly with our own matrix strategy, instead of the `cpan-test.yml` **reusable workflow**:

- `fail-fast: false`, so one failing cell no longer cancels its healthy siblings
- `os: [ ubuntu-latest, macos-latest, windows-latest ]` restored
- Perl versions unchanged: 5.24, 5.30, 5.36, 5.40

`coverage` and `perlcritic` jobs are untouched.

## Reasoning

Both issues were filed in Jan 2026 against CI logs GitHub has since expired (the API returns 410 for those runs), so neither can be re-diagnosed from evidence — only re-measured. **This PR is the measurement, not a claimed fix.**

**macOS (#10) most likely never had a macOS-specific fault.** The recorded symptom is `The operation was canceled` *after* all four dependencies installed successfully. That is the signature of matrix fail-fast cancelling a healthy cell when a sibling fails — not a test failure. Windows failed first and took macOS down with it. Issue #10's own investigation list opens with "Run CI with `fail-fast: false` to isolate macOS failures from Windows".

**Windows (#9) reported `No MYMETA file is found after configure. Your toolchain is too old?`.** Upstream PerlToolsTeam has since landed the matching fixes:

| Date | Commit | Change |
|---|---|---|
| 2026-02-11 | `eb7e0211` | Fix Windows CI: use PowerShell instead of bash |
| 2026-03-12 | `d8e20b78` | Make sure we have an up to date toolchain |
| 2026-04-20 | `1fba8505` | Improve toolchain |

We track `@main`, so these are already in our path — we simply never retested after pinning to Linux on 2026-01-22.

### Alternative considered

Keep the `cpan-test.yml` reusable workflow and call it three times, once per OS. Rejected: it produces three separate check entries for one logical test matrix, and still leaves fail-fast active *within* each OS, so a single bad Perl version would still mask the others on that platform. The reusable workflow fixes its own `strategy` block and exposes no `fail-fast` input, so the only way to set it is to call the composite action that the reusable workflow itself wraps — same action, same inputs, one layer down. A comment in the workflow records why.

### Deliberately not done

Pinning the action to a SHA. Every workflow reference in this repo tracks `@main`; changing that is a separate supply-chain decision, not part of a CI re-enablement.

## Verification

Local baseline on this branch is green (perl 5.38.2, `make test`): `t/regression.t`, `t/Reuse.t`, `t/test.t` — 26 tests, all pass. The real verification is this PR's own CI run across all 12 cells.

**Load-bearing: no.** CI configuration only; no shipped code changes.

## Expected outcomes

- All 12 cells green → both #9 and #10 close as fixed upstream.
- macOS green, Windows red → #10 was cross-cancellation (closes); #9 is real and now has fresh, unexpired logs to work from.
- macOS red → a genuine macOS fault exists, newly visible for the first time.

Whichever way it lands, the follow-up is driven by evidence rather than by January's expired logs.
