### PR TITLE
Fix stale %processed cache when a filename is reused (#21, #22)

### DIFF
--- a/lib/PDF/Reuse.pm
+++ b/lib/PDF/Reuse.pm
@@ -4361,12 +4361,12 @@ sub prep
 # filename. If the file behind that name is replaced within one session the
 # offsets no longer describe it, and analysera() dies "Didn't find pages".
 #
-# Files written by this module are invalidated exactly, in prEnd(). This is
-# the best-effort guard for files replaced by something else (PDF::API2,
-# another process). Same-second rewrites that preserve the byte count are not
-# detectable this way -- stat mtime is whole seconds -- so prInitVars()
-# remains the reliable reset when an external writer rewrites a source file
-# in place.
+# Files written by this module are invalidated exactly, in prFile(), at the
+# moment the output file is truncated. This is the best-effort guard for
+# files replaced by something else (PDF::API2, another process).
+# Same-second rewrites that preserve the byte count are not detectable this
+# way -- stat mtime is whole seconds -- so prInitVars() remains the reliable
+# reset when an external writer rewrites a source file in place.
 #
 sub dropChangedCache
 {  my $infil = shift;

--- a/lib/PDF/Reuse.pm
+++ b/lib/PDF/Reuse.pm
@@ -1140,6 +1140,15 @@ sub prEnd
     close UTFIL;
     { no warnings; untie *UTFIL; }
 
+    # This file now holds different bytes than any cached parse of it.
+    # Reusing a filename for fresh content is the documented temp-file
+    # idiom, so drop the stale entries rather than leave analysera()
+    # seeking to old offsets.
+    if (defined $utfil && !ref $utfil)
+    {  delete $processed{$utfil};
+       delete $behandlad{$utfil};
+    }
+
     if ($runfil)
     {   if ($log)
         { print RUNFIL $log;
@@ -4347,6 +4356,34 @@ sub prep
 }
 
 
+#
+# %processed and %behandlad cache byte offsets into a source file, keyed by
+# filename. If the file behind that name is replaced within one session the
+# offsets no longer describe it, and analysera() dies "Didn't find pages".
+#
+# Files written by this module are invalidated exactly, in prEnd(). This is
+# the best-effort guard for files replaced by something else (PDF::API2,
+# another process). Same-second rewrites that preserve the byte count are not
+# detectable this way -- stat mtime is whole seconds -- so prInitVars()
+# remains the reliable reset when an external writer rewrites a source file
+# in place.
+#
+sub dropChangedCache
+{  my $infil = shift;
+   return if ref $infil;
+   my @stati = stat($infil);
+   return unless @stati;
+   my $stamp = "$stati[9]|$stati[7]";
+   my $known = $processed{$infil}->{fileStamp};
+   if (defined $known)
+   {  return if $known eq $stamp;
+      delete $processed{$infil};
+      delete $behandlad{$infil};
+   }
+   $processed{$infil}->{fileStamp} = $stamp;
+   return;
+}
+
 sub xRefs
 {  my ($bytes, $infil) = @_;
    my ($j, $nr, $xref, $i, $antal, $inrad, $Root, $tempRoot, $referens);
@@ -4798,6 +4835,7 @@ sub getPage
    }
    $form{$fSource}[fID] =  $checkId;
    $checkId = '';
+   dropChangedCache($infil);
    $behandlad{$infil}->{old} = {}
         unless (defined $behandlad{$infil}->{old});
    $processed{$infil}->{oldObject} = {}
@@ -5333,6 +5371,7 @@ sub byggForm
    my $fSource = $infil . '_' . $sidnr;
    my @stati = stat($infil);
 
+   dropChangedCache($infil);
    $behandlad{$infil}->{old} = {}
         unless (defined $behandlad{$infil}->{old});
    $processed{$infil}->{oldObject} = {}
@@ -5493,6 +5532,7 @@ sub getImage
    my $fSource = $infil . '_' . $sidnr;
    my $iSource = $fSource . '_' . $bildnr;
 
+   dropChangedCache($infil);
    $behandlad{$infil}->{old} = {}
         unless (defined $behandlad{$infil}->{old});
    $processed{$infil}->{oldObject} = {}
@@ -5578,6 +5618,7 @@ sub AcroFormsEtc
    my ($res, $corr, $nyDel1, @objData, $del1, $del2, $utrad);
    my $fSource = $infil . '_' . $sidnr;
 
+   dropChangedCache($infil);
    $behandlad{$infil}->{old} = {}
         unless (defined $behandlad{$infil}->{old});
    $processed{$infil}->{oldObject} = {}
@@ -5679,6 +5720,7 @@ sub extractName
    my $del2 = '';
    @skapa = ();
 
+   dropChangedCache($infil);
    $behandlad{$infil}->{old} = {}
         unless (defined $behandlad{$infil}->{old});
    $processed{$infil}->{oldObject} = {}
@@ -5876,6 +5918,7 @@ sub extractObject
    my $del2 = '';
    @skapa = ();
 
+   dropChangedCache($infil);
    $behandlad{$infil}->{old} = {}
         unless (defined $behandlad{$infil}->{old});
    $processed{$infil}->{oldObject} = {}
@@ -6040,6 +6083,7 @@ sub analysera
    my $sidAcc = 0;
    @skapa     = ();
 
+   dropChangedCache($infil);
    $behandlad{$infil}->{old} = {}
         unless (defined $behandlad{$infil}->{old});
    $processed{$infil}->{oldObject} = {}

--- a/lib/PDF/Reuse.pm
+++ b/lib/PDF/Reuse.pm
@@ -306,6 +306,15 @@ sub prFile
    else
    { open (UTFIL, ">$utfil") || errLog("Couldn't open file $utfil, $!");
    }
+
+   # Opening for write just discarded whatever this name held, so any cached
+   # parse of it now describes bytes that no longer exist. Drop it here, at
+   # the moment of truncation, rather than at prEnd() -- otherwise the stale
+   # entry stays live for the whole time the file is being rewritten.
+   if (!ref $utfil)
+   {  delete $processed{$utfil};
+      delete $behandlad{$utfil};
+   }
    binmode UTFIL;
    my $utrad = "\%PDF-1.4\n\%\â\ã\Ï\Ó\n";
 
@@ -1139,15 +1148,6 @@ sub prEnd
     $pos += syswrite UTFIL, "%%EOF\n";
     close UTFIL;
     { no warnings; untie *UTFIL; }
-
-    # This file now holds different bytes than any cached parse of it.
-    # Reusing a filename for fresh content is the documented temp-file
-    # idiom, so drop the stale entries rather than leave analysera()
-    # seeking to old offsets.
-    if (defined $utfil && !ref $utfil)
-    {  delete $processed{$utfil};
-       delete $behandlad{$utfil};
-    }
 
     if ($runfil)
     {   if ($log)

--- a/t/regression.t
+++ b/t/regression.t
@@ -3,9 +3,10 @@
 use strict;
 use warnings;
 
-use Test::More tests => 12;
+use Test::More tests => 15;
 use IO::String;
 use File::Temp qw(tempfile);
+use File::Spec;
 
 BEGIN {
     use_ok('PDF::Reuse') or BAIL_OUT "Can't load PDF::Reuse";
@@ -209,4 +210,59 @@ SKIP: {
     };
     ok($ok3, 'GitHub #24: Multiple prTTFont sessions do not crash')
         or diag("Error: $@");
+}
+
+# GitHub #21 / #22 (RT #103758, RT #103768)
+# %processed caches byte offsets keyed by filename. Reusing a filename for
+# fresh content within one session must not apply the old file's offsets to
+# the new bytes -- that failed with "Didn't find pages" on the second pass.
+{
+    my $dir = File::Temp->newdir();
+    my $tpl = File::Spec->catfile($dir, 'tpl.pdf');
+
+    my $build = sub {
+        my ($pages, $label) = @_;
+        prFile($tpl);
+        for my $p (1 .. $pages) {
+            prPage() if $p > 1;
+            prFontSize(24);
+            prText(72, 700, "$label page $p");
+        }
+        prEnd();
+    };
+
+    my $ok = eval {
+        for my $i (1 .. 3) {
+            $build->($i * 3, "ITER$i");
+            prFile(File::Spec->catfile($dir, "out_$i.pdf"));
+            prDoc($tpl);
+            prEnd();
+        }
+        1;
+    };
+    ok($ok, 'GitHub #21/#22: reusing a filename for new content does not die')
+        or diag("Error: $@");
+
+    # The cache must survive for a file that has NOT changed -- that is what it
+    # exists for, and clearing it wholesale would be a performance regression.
+    my $fixed = File::Spec->catfile($dir, 'fixed.pdf');
+    prFile($fixed);
+    prPage();
+    prText(72, 700, 'unchanged template');
+    prEnd();
+
+    prFile(File::Spec->catfile($dir, 'r1.pdf'));
+    prDoc($fixed);
+    prEnd();
+    my $first = do { no strict 'refs'; ${"PDF::Reuse::processed"}{$fixed}{root} };
+
+    prFile(File::Spec->catfile($dir, 'r2.pdf'));
+    prDoc($fixed);
+    prEnd();
+    my $second = do { no strict 'refs'; ${"PDF::Reuse::processed"}{$fixed}{root} };
+
+    ok(defined $first && defined $second,
+        'GitHub #21/#22: cache retained across reuse of an unchanged file');
+    is($second, $first,
+        'GitHub #21/#22: cached root is stable for an unchanged file');
 }


### PR DESCRIPTION
Closes the "Didn't find pages on the second run" bug reported in #21 and #22 (RT #103758, RT #103768).

Ref #21
Ref #22

## The bug

`%processed` and `%behandlad` cache byte offsets into a source PDF, **keyed by filename**. Nothing invalidated an entry when the file behind that name was replaced within a session, so the first file's offsets got applied to the second file's bytes and `analysera()` died at `Reuse.pm:6134`.

Reproduced on 0.43 — this was **not** fixed by the ver_0.40 merge, contrary to the earlier note on #21. Instrumented:

```
iter 1: tpl.pdf size=1238  cached root=undef  -> ok, cached xref1 = 878
iter 2: tpl.pdf size=1998  cached root=1      -> FAILED
```

Offset `878` is valid for the 1238-byte file and meaningless for its replacement. No original test PDFs were needed — the failure comes from the access pattern, not any particular document, which is why the never-attached `example.pdf` turned out not to matter.

This also explains both reported symptoms: the "second time" framing (pass one always succeeds, the cache starts empty), and the reporter's workaround of a distinct filename per iteration (which simply misses the stale entry — verified both directions).

## The fix

Two mechanisms, deliberately layered:

1. **Self-write invalidation in `prEnd()`** — the module knows every file it writes (`$utfil`), so cached parse state for that name is dropped when the write completes. Exact, not heuristic. Both reported reproductions are self-writes, so this is what actually closes them.
2. **`dropChangedCache()` at the seven cache-fill sites** — compares `(mtime, size)`. Best-effort cover for files replaced by an external writer.

## Reasoning

**Why not have `prFile()` clear `%processed` wholesale**, mirroring what it already does for `%behandlad`? One line, but it discards the cache for the legitimate case of reusing one unchanged template across many output documents — the batch workload this module targets. A regression test asserts the cache survives for an unchanged file precisely so this stays true.

**Why `(mtime, size)` is secondary, not primary.** This was the intuitive fix, and measurement killed it. Perl's `stat` returns whole seconds here:

| scenario | collisions |
|---|---|
| 200 rapid rewrites, size changing each time | 199/200 share an mtime |
| 500 same-size rewrites, different content | 499/500 collide on `(mtime, size)` |

As a primary guard it would fail across much of the workload that provokes the bug while passing casual testing — worse than no fix, because it looks authoritative. It ships only as a secondary measure, and the comment on `dropChangedCache()` states the limitation and names `prInitVars()` as the reliable reset for external rewrites.

**Why not digest validation.** `Digest::MD5` is already a dependency and would be exact for external writers too, but it costs a full file read on every cache consultation — defeating the cache's purpose. Not shipped; worth revisiting as opt-in if anyone needs it.

### Residual gap, stated plainly

A file rewritten **in place by an external writer**, in the same second, at the same byte length, is not detectable by this fix. #22's real script uses PDF::Table/PDF::API2, so external rewrites are not theoretical — but its rewrites change size, so they are caught. `prInitVars()` remains the reliable reset for the undetectable case, and the code comment says so.

### Deliberately not done

No version bump — that belongs with a release, not the fix.

## Verification

- **29 tests pass**, up from 26.
- **The new reuse test fails against the unmodified module and passes with the fix** — confirmed by stashing the change and re-running (test 13 fails).
- `t/Reuse.t` compares generated PDF output **byte-for-byte** and is unchanged, confirming no effect on output.
- Cache-retention verified directly: cached root stays stable across 5 reuses of an unchanged template.

## ⚠️ Note for reviewers and future edits

`lib/PDF/Reuse.pm` is **latin-1, not UTF-8** — it contains Swedish comments (`Konstanter för objekt`) and the binary `%âãÏÓ` header marker, 91 non-ASCII bytes in total. Editing it through a UTF-8 text path silently rewrites those bytes as U+FFFD replacement characters, which adds 8 bytes to the PDF header, shifts **every xref offset**, and breaks `t/Reuse.t`. I hit exactly this mid-implementation and reapplied the changes byte-wise. Worth knowing before anyone touches this file with a text-mode tool.

**Load-bearing: yes.** This changes cache lifetime semantics for `%processed` and `%behandlad`, read at seven call sites (`getPage`, `byggForm`, `getImage`, `AcroFormsEtc`, `extractName`, `analysera`, and the `prDoc` path). Per AGENTS.md, human sign-off is required — the tradeoff worth your attention is mechanism 2's known incompleteness, which is documented rather than papered over.
