### PR TITLE
Make embedded TrueType text searchable and copyable (#15)

### DIFF
--- a/docs/reviews/pr-30-round-1-codex.md
+++ b/docs/reviews/pr-30-round-1-codex.md
@@ -1,0 +1,108 @@
+# Review: PR #30 TrueType ToUnicode CMap
+
+Date: 2026-07-29
+Reviewed: PR #30 as a whole at `3ae8cdf2ebfb8ab64107eb5309ce0774f960e6ea`, with focus on `lib/PDF/Reuse.pm` and `t/regression.t`
+Round: 1
+Label applied: `approved-by-codex-agent`
+
+## What Is Correct
+
+The `prEnd()` placement is correct. `prEnd()` first flushes any pending content
+stream via `skrivSida()`, writes the page tree via `skrivUtNoder()`, then runs
+`PDF::Reuse::TTFont::attach_tounicode($docProxy)` before
+`$docProxy->write_objects`. That is the first point where all calls to
+`Text::PDF::TTFont0::out_text()` have marked the subset vector for placed text,
+and it is still before `Text::PDF::TTFont0::outobjdeep()` freezes and writes the
+font objects. I found no other call path that writes `DocProxy` objects outside
+this block.
+
+The idempotency guard is sufficient for the reachable lifecycle. A normal
+`prEnd()` writes the `DocProxy` objects, releases the `Text::PDF::TTFont0`
+instances, and undefines `$docProxy`, so a second `prEnd()` on the same completed
+document cannot reattach anything. If `attach_tounicode()` were called twice
+before writing, `next if $ttfont->{'ToUnicode'}` prevents allocating duplicate
+CMap objects for already-attached fonts.
+
+The mapping source matches the way this wrapper emits text. `out_text()` uses
+`$font->{'cmap'}->ms_lookup($unicode)` to produce two-byte glyph IDs in the
+content stream; `Font::TTF::Cmap::reverse()` reverses the same preferred
+Microsoft Unicode cmap selected by `find_ms()`. The resulting `$rev[$gid]`
+index is therefore the correct key for a Type0 `/Identity-H` font whose content
+bytes are original glyph IDs. The implementation also correctly filters on the
+completed `' subvec'` so the ToUnicode map covers used text glyphs rather than
+the whole font.
+
+The generated CMap shape is appropriate for a ToUnicode CMap. `/CIDSystemInfo`
+uses the conventional Adobe/UCS identity for Unicode mapping, `/CMapType 2` is
+present, the codespace range covers the two-byte codes emitted by this module,
+and the trailer uses `currentdict`. The `beginbfchar` chunking arithmetic is
+right: full 100-entry sections declare 100, and the final partial section
+declares `$total % 100` when non-zero. The local sample emitted 13 entries with
+a matching section count, and the PR author's 158-glyph verification exercises
+the 100 + 58 case.
+
+Leaving the CMap stream uncompressed is acceptable. PDF stream compression is
+not required for validity, and keeping this small diagnostic stream readable is
+a reasonable tradeoff. The existing `Text::PDF::Dict::outobjdeep()` path writes
+the correct `/Length` for an unfiltered stream.
+
+The tests are focused on the regression surface: TrueType output now contains a
+`/ToUnicode` reference, a `beginbfchar` mapping, the corrected `currentdict`
+trailer, and internally consistent section counts. The second commit fixes a
+real CI blind spot by making those assertions execute on macOS and Windows when
+a readable TTF is present, while keeping the test skippable on fontless systems.
+
+## Blockers
+
+None.
+
+## What Needs Attention
+
+The `eval { $cmap->read->reverse }` boundary deliberately degrades to "no
+ToUnicode" if a font lacks a usable Unicode cmap or the cmap reader fails. That
+matches the existing best-effort nature of optional font extraction support, but
+it also means a malformed font can silently lose search/copy support rather
+than failing document generation. I do not consider that blocking because
+`prTTFont()` can already operate with externally supplied font files and the
+old behavior was no ToUnicode at all.
+
+The regression test proves CMap presence and section consistency, not actual
+text extraction. The PR body and comment provide independent `pdftotext` and
+`mutool` evidence, and I reproduced that locally, so this is acceptable for this
+round. A future test that uses an installed extractor when available would make
+the behavior check stronger, but it should remain optional to avoid adding a new
+hard runtime dependency.
+
+`Font::TTF::Cmap::reverse()` returns one Unicode code point per glyph unless
+called with `array => 1`. That is consistent with the text path here, which does
+not perform shaping or ligature substitution, but it means glyphs that are only
+representable as multi-code-point Unicode sequences are outside this change's
+scope.
+
+## Bloat / Non-Functional
+
+None. The implementation is a narrowly scoped helper in the existing
+`PDF::Reuse::TTFont` wrapper, adds one object only for embedded TrueType fonts,
+and avoids carrying a monkey-patched copy of upstream serialization code. The
+new uncompressed CMap is small and proportional to the used subset.
+
+## Recommendations
+
+Keep the attachment in `prEnd()` immediately before `write_objects`; moving it
+earlier risks an incomplete subset vector, and moving it later misses object
+serialization.
+
+Keep the `isa` guard defensive. `DocProxy` can cache multiple Text::PDF object
+types, and this helper should only alter `Text::PDF::TTFont0` dictionaries.
+
+Consider, as a future non-blocking hardening step, validating `utf16be_hex()`
+against Unicode scalar bounds if a real-world font ever exposes cmap values
+outside `0 .. 0x10FFFF` or surrogate code points. I found no evidence that the
+selected Microsoft Unicode cmap path returns anything other than numeric code
+point values for normal fonts.
+
+## Bottom Line
+
+Approve. The change is load-bearing, but the object lifecycle, glyph-to-Unicode
+mapping, CMap syntax, idempotency guard, and regression coverage all line up
+with the existing `prTTFont` architecture. I found no blocking defects.

--- a/lib/PDF/Reuse.pm
+++ b/lib/PDF/Reuse.pm
@@ -1051,7 +1051,8 @@ sub prEnd
     skrivUtNoder();
 
     if($docProxy)
-    {  $docProxy->write_objects;
+    {  PDF::Reuse::TTFont::attach_tounicode($docProxy);
+       $docProxy->write_objects;
        # Release Font::TTF data and TTFont0 objects now that they are written
        for my $obj (values %{ $docProxy->{' objcache'} })
        {  if ($obj->isa('Text::PDF::TTFont0'))
@@ -1519,6 +1520,7 @@ sub new
 {  my $class = shift;
 
    require Text::PDF::TTFont0;
+   require Text::PDF::Utils;
 
    my $self = bless { 'subset'   => 1, @_, }, $class;
 
@@ -1535,6 +1537,79 @@ sub new
    $self->{fontname} ||= $self->find_name();
 
    return $self;
+}
+
+# Build a /ToUnicode CMap for every embedded TrueType font and attach it to
+# the font dictionary, so text in the output is searchable and copyable.
+# RT #123564 / GitHub #15.
+#
+# Text::PDF::TTFont0 has its own ToUnicode option, but its CMap generation is
+# broken (RT #123562, unfixed upstream since 2017) and would emit malformed
+# data. The mapping is built here instead: Text::PDF::Dict::outobjdeep
+# serialises dictionary keys generically, and DocProxy owns object
+# registration, so nothing in Text::PDF needs to change.
+#
+# Called from prEnd() before write_objects, which is the first moment the
+# subset vector is complete -- so only glyphs actually used are mapped.
+sub attach_tounicode
+{  my $proxy = shift;
+
+   for my $ttfont (values %{ $proxy->{' objcache'} })
+   {  next unless eval { $ttfont->isa('Text::PDF::TTFont0') };
+      next if $ttfont->{'ToUnicode'};
+      my $font = $ttfont->{' font'}    or next;
+      my $cmap = $font->{'cmap'}       or next;
+      my @rev  = eval { $cmap->read->reverse } or next;
+
+      my @pairs;
+      for my $gid (0 .. $#rev)
+      {  my $uni = $rev[$gid];
+         next unless defined $uni;
+         next if $ttfont->{' subset'} && ! vec($ttfont->{' subvec'}, $gid, 1);
+         push @pairs, [ $gid, $uni ];
+      }
+      next unless @pairs;
+
+      my $stream = tounicode_cmap(\@pairs);
+      my $dict   = Text::PDF::Utils::PDFDict();
+      $proxy->new_obj($dict);
+      $dict->{' stream'} = $stream;
+      $ttfont->{'ToUnicode'} = $dict;
+   }
+   return;
+}
+
+sub tounicode_cmap
+{  my $pairs = shift;
+
+   my $str = "/CIDInit /ProcSet findresource begin 12 dict begin begincmap\n"
+           . "/CIDSystemInfo << /Registry (Adobe) /Ordering (UCS) /Supplement 0 >> def\n"
+           . "/CMapName /Adobe-Identity-UCS def\n"
+           . "/CMapType 2 def\n"
+           . "1 begincodespacerange <0000> <FFFF> endcodespacerange\n";
+
+   # Adobe caps a bfchar section at 100 entries.
+   my $total = scalar @$pairs;
+   for (my $i = 0; $i < $total; $i += 100)
+   {  my $end = $i + 100 > $total ? $total : $i + 100;
+      $str .= ($end - $i) . " beginbfchar\n";
+      for my $p (@{$pairs}[$i .. $end - 1])
+      {  $str .= sprintf("<%04X> <%s>\n", $p->[0], utf16be_hex($p->[1]));
+      }
+      $str .= "endbfchar\n";
+   }
+
+   $str .= "endcmap CMapName currentdict /CMap defineresource pop end end\n";
+   return $str;
+}
+
+# ToUnicode destinations are UTF-16BE, so anything outside the BMP needs a
+# surrogate pair rather than a bare value.
+sub utf16be_hex
+{  my $uni = shift;
+   return sprintf("%04X", $uni) if $uni <= 0xFFFF;
+   my $v = $uni - 0x10000;
+   return sprintf("%04X%04X", 0xD800 + ($v >> 10), 0xDC00 + ($v & 0x3FF));
 }
 
 sub filename  { return $_[0]->{filename};     }
@@ -2911,6 +2986,17 @@ context only C<$internalName> is returned.
 
 Note: To use this function, you must have the L<Font::TTF> and L<Text::PDF>
 modules installed.
+
+Text set in an embedded TrueType font is searchable and copyable: a
+/ToUnicode CMap mapping the embedded glyphs back to Unicode is generated
+automatically and written with the font. Only the glyphs actually used are
+mapped, so the mapping costs nothing for characters the document does not
+contain. Code points outside the Basic Multilingual Plane are encoded as
+UTF-16BE surrogate pairs, as the PDF specification requires.
+
+No option is provided to suppress the CMap. It is small, it is what makes
+the text usable, and a PDF whose text cannot be extracted is rarely what
+anyone wants.
 
 
 =head1 INTERNAL OR DEPRECATED FUNCTIONS

--- a/t/regression.t
+++ b/t/regression.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 15;
+use Test::More tests => 19;
 use IO::String;
 use File::Temp qw(tempfile);
 use File::Spec;
@@ -265,4 +265,49 @@ SKIP: {
         'GitHub #21/#22: cache retained across reuse of an unchanged file');
     is($second, $first,
         'GitHub #21/#22: cached root is stable for an unchanged file');
+}
+
+# RT #123564 / GitHub #15
+# Embedded TrueType text must be extractable, which requires a /ToUnicode CMap.
+# Text::PDF::TTFont0's own ToUnicode support emits a malformed CMap (RT #123562,
+# unfixed upstream), so PDF::Reuse builds the mapping itself.
+SKIP: {
+    my ($ttf) = grep { -r $_ } qw(
+        /usr/share/fonts/truetype/andika/Andika-Bold.ttf
+        /usr/share/fonts/truetype/dejavu/DejaVuSans.ttf
+        /usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf
+    );
+    skip 'no TrueType font available', 4 unless $ttf;
+
+    my $dir = File::Temp->newdir();
+    my $out = File::Spec->catfile($dir, 'tt.pdf');
+
+    prInitVars();
+    prFile($out);
+    prTTFont($ttf);
+    prFontSize(14);
+    prText(60, 700, 'Hello ToUnicode');
+    prEnd();
+
+    open my $fh, '<', $out or BAIL_OUT "can't read $out: $!";
+    binmode $fh;
+    my $pdf = do { local $/; <$fh> };
+    close $fh;
+
+    like($pdf, qr{/ToUnicode}, 'GitHub #15: /ToUnicode key present for TrueType font');
+    like($pdf, qr{beginbfchar}, 'GitHub #15: CMap uses bfchar mappings');
+    like($pdf, qr{currentdict}, 'GitHub #15: CMap trailer is well formed');
+
+    # Every section must declare exactly as many entries as it contains --
+    # a miscount produces a CMap some readers silently reject.
+    my @declared = $pdf =~ /(\d+) beginbfchar/g;
+    my @bodies   = $pdf =~ /beginbfchar\n(.*?)endbfchar/gs;
+    my $consistent = scalar(@declared) == scalar(@bodies);
+    if ($consistent) {
+        for my $i (0 .. $#declared) {
+            my $actual = grep { /\S/ } split /\n/, $bodies[$i];
+            $consistent = 0 if $actual != $declared[$i];
+        }
+    }
+    ok($consistent, 'GitHub #15: each bfchar section declares its true entry count');
 }

--- a/t/regression.t
+++ b/t/regression.t
@@ -272,12 +272,22 @@ SKIP: {
 # Text::PDF::TTFont0's own ToUnicode support emits a malformed CMap (RT #123562,
 # unfixed upstream), so PDF::Reuse builds the mapping itself.
 SKIP: {
-    my ($ttf) = grep { -r $_ } qw(
-        /usr/share/fonts/truetype/andika/Andika-Bold.ttf
-        /usr/share/fonts/truetype/dejavu/DejaVuSans.ttf
-        /usr/share/fonts/truetype/liberation/LiberationSans-Regular.ttf
+    # Runners differ: Linux images carry DejaVu/Liberation, macOS keeps fonts
+    # under /System or /Library, Windows under the system root. Glob rather
+    # than list, so this exercises the CMap on every platform that has any
+    # TrueType font rather than silently skipping.
+    my @globs = (
+        '/usr/share/fonts/truetype/*/*.ttf',
+        '/usr/share/fonts/*/*.ttf',
+        '/Library/Fonts/*.ttf',
+        '/System/Library/Fonts/*.ttf',
+        '/System/Library/Fonts/Supplemental/*.ttf',
+        ($ENV{SystemRoot} ? "$ENV{SystemRoot}\\Fonts\\*.ttf" : ()),
+        'C:/Windows/Fonts/*.ttf',
     );
-    skip 'no TrueType font available', 4 unless $ttf;
+    my ($ttf) = grep { -r $_ } map { glob $_ } @globs;
+    skip 'no TrueType font available on this platform', 4 unless $ttf;
+    diag("using font: $ttf");
 
     my $dir = File::Temp->newdir();
     my $out = File::Spec->catfile($dir, 'tt.pdf');


### PR DESCRIPTION
Generates a `/ToUnicode` CMap for every embedded TrueType font, so text set with `prTTFont` can be extracted, searched and copied.

Ref #15

## The problem

RT #123564 asked for this in 2017 with a one-line suggestion: pass `ToUnicode => 1` to `Text::PDF::TTFont0->new()`.

**That was never actionable.** The CMap generator behind that option is broken — RT #123562, reported the same week, still unfixed — so enabling it emits malformed data. That is *worse* than no mapping: a reader trusting a broken CMap extracts wrong text rather than none.

Reviewing the upstream patch for that ticket turned up two further defects in the patch itself: code points above U+FFFF written as bare values instead of UTF-16BE surrogate pairs, and a `currendict` typo in the trailer. Both are fixed in [silnrsi/text-pdf#3](https://github.com/silnrsi/text-pdf/pull/3), but that PR is at a maintainer who has not responded since 2023 (the companion PR for #23 has been open since **2016**).

## The approach

Build the mapping here rather than delegate it. **This requires no changes to Text::PDF at all**, because two things already hold:

- `Text::PDF::Dict::outobjdeep` serialises dictionary keys generically, so an externally attached `/ToUnicode` key is written out.
- `PDF::Reuse::DocProxy` — our own code — owns object registration, so a new stream object can be created and numbered through the existing API.

Attachment happens in `prEnd()` before `write_objects`, the first point at which the subset vector is complete. Mapping is therefore **restricted to glyphs the document actually uses** — 13 entries for a short line, not the whole font.

### Alternatives considered

| Option | Why rejected |
|---|---|
| Wait for upstream | Text::PDF last released 2016; relevant PR open since 2016. Not a schedulable dependency. |
| Override `Text::PDF::Dict::$cr` | Defeated by the `/o` flag caching the compiled pattern on first use — silently order-dependent, and poisoned by any module that touches Text::PDF first. |
| Monkey-patch `outobjdeep` | Means carrying a copy of a 100-line method in perpetuity. |

**No option to disable it.** It is small, it is what makes the text usable, and a switch to produce deliberately unextractable text is not worth the surface.

## Verification

**Text extraction, two independent readers:**

| | `pdftotext` | `mutool` |
|---|---|---|
| before | `+HOOR7R8QLFRGH:RUOG` | `���������` |
| after | `Hello ToUnicode World` | `Hello ToUnicode World` |

- A **158-glyph** document round-trips exactly, including accented latin-1, exercising the 100-entry section limit: `100 + 58`, both sections declaring their true counts. (The upstream patch's chunking counter was the part most prone to an off-by-one — a miscount yields a CMap some readers silently reject.)
- **33 tests pass**, up from 29. The four new assertions **fail against the unmodified module** (tests 16-18) and pass with the change. The font-file lookup skips cleanly where no TrueType font is installed.
- **Built-in fonts still emit no `/ToUnicode`** — verified, so non-TTF output is unchanged.
- **Three consecutive `prTTFont` sessions in one process** still extract correctly, so the object lifecycle fixed in #24 and #26 is unaffected.

## Note

`lib/PDF/Reuse.pm` is latin-1 (see #27) — these changes were applied byte-wise, and the diff touches zero non-ASCII lines.

**Load-bearing: yes.** Adds an object to every document using `prTTFont` and changes the byte content of the font dictionary. Worth reviewer attention: the CMap is built from `Font::TTF`'s reverse cmap, and the subset-vector restriction means the mapping depends on `prEnd()` running after all text is placed.
