### PR TITLE
Release v0.44

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,21 @@
 Revision history for Perl extension PDF::Reuse
 
+0.44 Wed Jul 29 2026
+     - Embedded TrueType text is now searchable and copyable (GitHub #15,
+       RT #123564). A /ToUnicode CMap is generated for each embedded font,
+       covering only the glyphs actually used. Built here rather than via
+       Text::PDF::TTFont0, whose ToUnicode support emits a malformed CMap
+       (RT #123562, unfixed upstream).
+     - Fix "Didn't find pages" when a source filename is reused within one
+       session (GitHub #21, #22, RT #103758, RT #103768). %processed cached
+       byte offsets keyed by filename and was never invalidated when the
+       file behind that name was replaced, so the first file's offsets were
+       applied to the second file's bytes.
+     - CI now covers Linux, macOS and Windows again, with per-platform
+       isolation so one failing cell no longer masks the others
+       (GitHub #9, #10). Upstream workflow references are pinned to a SHA;
+       see docs/ci-pin-maintenance.md.
+
 0.43 Thu Jan 23 2026
      - Fix prTTFont/prEnd crash from orphaned docProxy (GitHub #24)
        DESTROY was releasing TTFont0 objects still owned by DocProxy,

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,15 +1,17 @@
 Changes
 CONTRIBUTING.md
+docs/ci-pin-maintenance.md
+lib/PDF/Reuse.pm
+lib/PDF/Reuse/Util.pm
+lib/PDF/Util/graphObj_pl
+lib/PDF/Util/reuseComponent_pl
 LICENSE
 Makefile.PL
 MANIFEST
+MANIFEST.SKIP
+META.yml			Module meta-data (added by MakeMaker)
 README
 SECURITY.md
-lib/PDF/Reuse.pm
-t/test.t
-t/Reuse.t
 t/regression.t
-lib/PDF/Util/reuseComponent_pl
-lib/PDF/Util/graphObj_pl
-lib/PDF/Reuse/Util.pm
-META.yml                                 Module meta-data (added by MakeMaker)
+t/Reuse.t
+t/test.t

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,0 +1,24 @@
+# Version control and build products
+^\.git/
+^blib/
+^Makefile$
+^Makefile\.old$
+^pm_to_blib$
+^MYMETA\.
+^MANIFEST\.bak$
+\.tar\.gz$
+
+# CI and repository furniture, not part of the distribution
+^\.github/
+^\.gitignore$
+
+# Code review artifacts are a record of how a change was reviewed here.
+# They are meaningful in the repository and noise on CPAN.
+^docs/reviews/
+
+# Editor and OS leavings
+~$
+^\.vscode/
+^\.idea/
+\.swp$
+^\.DS_Store$

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -32,7 +32,7 @@ WriteMakefile1(
         provides => {
             'PDF::Reuse' => {
                 file    => 'lib/PDF/Reuse.pm',
-                version => '0.43',
+                version => '0.44',
             },
             'PDF::Reuse::Util' => {
                 file    => 'lib/PDF/Reuse/Util.pm',

--- a/lib/PDF/Reuse.pm
+++ b/lib/PDF/Reuse.pm
@@ -15,7 +15,7 @@ use Compress::Zlib qw(compress inflateInit);
 use autouse 'Data::Dumper'   => qw(Dumper);
 #use AutoLoader qw(AUTOLOAD);
 
-our $VERSION = '0.43';
+our $VERSION = '0.44';
 our @ISA     = qw(Exporter);
 our @EXPORT  = qw(prFile
                   prPage


### PR DESCRIPTION
Version bump, Changes entry, and MANIFEST curation for the 0.44 release.

Ref #15
Ref #21
Ref #22

## What ships

Three user-visible changes since 0.43, all already reviewed and merged:

| | |
|---|---|
| **#15** | Embedded TrueType text is searchable and copyable — a `/ToUnicode` CMap is generated per font, covering only the glyphs actually used. **This is what Koha's PDF work needs.** |
| **#21, #22** | `Didn't find pages` when a source filename is reused within one session. An eleven-year-old RT report. |
| **#9, #10** | CI covers Linux, macOS and Windows again with per-platform isolation. |

## MANIFEST.SKIP is new

This distribution had none, so `make manifest` swept in the previous release tarball and every `docs/reviews/*` artifact. Neither belongs on CPAN — the review artifacts record how a change was reviewed *in this repository* and are noise to anyone installing the module.

`docs/ci-pin-maintenance.md` **is** shipped deliberately: it explains why upstream CI refs are pinned and how to advance them, which is useful to anyone packaging this.

## The tarball is not committed

No previous release tarball is tracked, and `*.tar.gz` is already in `.gitignore` — committing this one would be the inconsistency, not omitting it. `PDF-Reuse-0.44.tar.gz` (74 KB) is built locally and ready for PAUSE.

## Verification

Verified **from the extracted tarball**, not the working tree — packaging bugs only show up that way:

```
$ tar xzf PDF-Reuse-0.44.tar.gz && cd PDF-Reuse-0.44
$ perl Makefile.PL && make && make test
All tests successful.   Files=3, Tests=33
```

Then an end-to-end check that the *shipped* module still does the thing this release is for:

```
$ pdftotext d.pdf -
Release 0.44 check
```

Tarball contents inspected by hand — no review artifacts, no old tarball, no CI config. Version reads `0.44` consistently across `Reuse.pm`, `Makefile.PL`, `META.yml` and `META.json`.

Tagged `v0.44` locally; the tag pushes with the merge.

## Deliberately not in this release

- **#28** — `%form`/`%intAct`/`%image` staleness. Pre-existing, and unsafe to fix from the invalidation point added in #26 because those entries are consumed mid-document.
- **#23** — the Text::PDF stream-length bug. Needs a fix in Text::PDF itself; the wrapper workaround is defeated by regex `/o` caching.
- **#27, #29** — latin-1 → UTF-8 conversion and Swedish comment translation. Housekeeping, no user-visible effect.

**Load-bearing: no.** Version metadata, changelog and packaging only; no code changes — all the code in this release was reviewed and merged in #25, #26 and #30.
