### PR TITLE
Drop all source-derived caches when a filename is rewritten (#28)

### DIFF
--- a/docs/reviews/pr-32-round-1-codex.md
+++ b/docs/reviews/pr-32-round-1-codex.md
@@ -1,0 +1,47 @@
+# Review: PR #32 stale source-derived cache invalidation
+
+Date: 2026-07-29
+Reviewed: PR #32 branch `fix/stale-form-caches` at `af09c6d63040d2a80da08a7e7cabbaad92ed3e17`
+Round: 1
+Label applied: changes-requested
+
+## What Is Correct
+
+The invalidation point is the right place for module-owned rewrites. `prFile()` has just opened the named output for write, and the per-document state reset follows immediately, so broadening the existing #26 invalidation there avoids deleting entries during an in-flight form/image/font emission path.
+
+Sweeping `%form`, `%image`, and `%intAct` is necessary. Those hashes survive across `prFile()` calls and are keyed from `$infil . '_' . $sidnr` or `$iSource`, so keeping them after a same-name rewrite preserves stale BBox, image dimensions/object numbers, and interactive-form data.
+
+Sweeping `%fontSource` is also directionally correct. `findFont()` uses `foSOURCE` to split back to a source filename/page and calls `extractObject()` when reusing a non-standard font, so a stale `foSOURCE` can point at bytes that no longer exist or now describe a different object.
+
+I did not find another package-level source-derived cache that survives `prFile()` and needs this same treatment. `%knownToFile`, `%objRef`, the `%sid*` resource maps, `%resurser`, `%fields`, `%script`, `%initScript`, `%links`, `%prefs`, `%embedded`, `%dummy`, and `%nyaFunk` are either document-local and reset from `prFile()`/page emission paths or are not keyed by the source filename in a way that survives the boundary being fixed here.
+
+Local verification passed with the requested command:
+
+```text
+PERL5LIB=~/perl5/lib/perl5 perl Makefile.PL && PERL5LIB=~/perl5/lib/perl5 make && PERL5LIB=~/perl5/lib/perl5 make test
+Files=3, Tests=37, Result: PASS
+```
+
+## Blockers
+
+1. `lib/PDF/Reuse.pm:4475` / `lib/PDF/Reuse.pm:4492` - The raw `$fil . '_'` prefix match can delete `%fontSource` entries for an unrelated source file, and for that cache the consequence is not limited to a needless re-parse. For example, rewriting `t.pdf` builds prefix `t.pdf_`, which also matches a cached `foSOURCE` value such as `t.pdf_backup_1`. If that entry is deleted, the next `prFile()` has already cleared `%font`, and a later `prFont($embedded_font_name)` no longer has the surviving `%fontSource` entry that `findFont()` needs to re-extract the embedded font. It can then fall through the "font not found" path and render with the standard/default font instead. Please anchor the scan on the page-number component, e.g. match `\A\Q$fil\E_\d+(?:_|$)` for the source-derived keys/values, with the existing `Ig:` prefix handled explicitly. That preserves regex-metacharacter safety while avoiding sibling filename collisions.
+
+## What Needs Attention
+
+The new regression covers the main stale BBox/mtime failure and confirms unchanged templates keep their cache. It does not cover the new `%fontSource` sweep. Once the prefix matching is anchored, add either a direct cache-level regression for the collision or a behavioral font reuse test if the fixture burden is acceptable.
+
+## Bloat / Non-Functional
+
+None. The helper is appropriately small for a load-bearing cache-lifetime change and replaces the previous inline deletes instead of duplicating them.
+
+## Recommendations
+
+Use one shared predicate for source-key matching so `%form`, `%intAct`, `%image`, `%knownToFile`, and `%fontSource` cannot drift. The important invariant is "filename exactly, then underscore, then page number, then either end-of-key or the next underscore-delimited component."
+
+Keep deleting the full `%fontSource` entry once it is exactly matched. Preserving `foORIGINALNR` while clearing only `foSOURCE` would leave a half-valid record whose original object number still came from the old source.
+
+Leaving ref-valued `$utfil` out of this sweep is correct. Ref outputs do not truncate a named file, and ref-valued inputs are materialized as temp files for parsing rather than invalidating a caller-visible source path.
+
+## Bottom Line
+
+Revise before merge. The invalidation site and cache set are right, but the unanchored prefix match is too broad for `%fontSource` and can silently change later font rendering for a different source file whose name collides with the rewritten filename prefix.

--- a/docs/reviews/pr-32-round-2-codex.md
+++ b/docs/reviews/pr-32-round-2-codex.md
@@ -1,0 +1,49 @@
+# Review: PR #32 stale source-derived cache invalidation
+
+Date: 2026-07-29
+Reviewed: PR #32 branch `fix/stale-form-caches` at `d6fa46907993bc6a76eb4639bc28ca354b6e5744`
+Round: 2
+Label applied: approved-by-codex-agent
+
+## What Is Correct
+
+The round-1 blocker is resolved. `dropSourceCaches()` now matches source-derived keys with `qr/\A\Q$fil\E_\d+(?:_|\z)/`, which preserves entries for sibling filenames such as `t.pdf_backup_1` when rewriting `t.pdf`, while still sweeping the rewritten file's own `t.pdf_1` and `t.pdf_1_2` entries.
+
+The anchor is correct for the cache shapes this PR sweeps. `%form` and `%intAct` use `$file_$page`; `%image` uses `$file_$page_$image`; `%fontSource` stores `$file_$page` in `foSOURCE`; and `%knownToFile` stores both `$file_$page` and `Ig:$file_$page_$image` for these form/image paths. I did not find a swept source-derived key where the page component is followed by anything other than an underscore or end-of-string.
+
+The `%fontSource` handling now avoids the user-visible failure from round 1. Deleting only entries whose `foSOURCE` belongs to the rewritten file keeps embedded-font provenance for sibling files intact, so `findFont()` can still re-extract those fonts after `prFile()` clears `%font`.
+
+The new cache-level collision regression is sufficient for this fix. It directly pins the ownership invariant that caused the blocker: a rewrite of the shorter filename sweeps the shorter file's cached `%form` entries and preserves the sibling filename's entries. A behavioral embedded-font fixture would add confidence for the downstream symptom, but it is not necessary to prove this matcher fix.
+
+Local verification passed with the requested command:
+
+```text
+PERL5LIB=~/perl5/lib/perl5 perl Makefile.PL && PERL5LIB=~/perl5/lib/perl5 make && PERL5LIB=~/perl5/lib/perl5 make test
+Files=3, Tests=40, Result: PASS
+```
+
+GitHub CI at `d6fa46907993bc6a76eb4639bc28ca354b6e5744` shows the 14 expected CI jobs successful.
+
+## Blockers
+
+None.
+
+## What Needs Attention
+
+The `%knownToFile` `Ig:` prefix remains an ambiguous legacy key shape: a form source literally named with an `Ig:` prefix can resemble the image-cache variant for the same spelling without `Ig:`. The current prefix-stripping approach does not introduce a new class of practical failure for this PR, because `%knownToFile` false positives only lose a name mapping while `%form`, `%image`, and `%fontSource` use the anchored owned-source test directly. A future structural cleanup could make the key type explicit, but that is outside this fix.
+
+The comments added around `dropSourceCaches()` are longer than this code usually needs, but they document the non-obvious cache lifetime and font failure mode that caused the blocker. I would keep them for this load-bearing cache invalidation path.
+
+## Bloat / Non-Functional
+
+None. The implementation remains a single helper with direct scans over the affected package hashes. The added regression is narrow and targeted to the reviewed collision.
+
+## Recommendations
+
+Do not require the behavioral embedded-font test for this PR. If embedded-font fixtures are added later, they should cover the broader `%fontSource` reuse behavior rather than just re-proving the filename matcher.
+
+If `%knownToFile` is revisited in a later cleanup, split form and image provenance into distinct keys or hashes instead of encoding the type as an `Ig:` string prefix.
+
+## Bottom Line
+
+Approve. The blocker is fixed, the anchored matcher is correct for the source-derived key shapes this PR invalidates, and the regression covers the cache ownership invariant without adding unnecessary fixture burden.

--- a/lib/PDF/Reuse.pm
+++ b/lib/PDF/Reuse.pm
@@ -312,8 +312,7 @@ sub prFile
    # the moment of truncation, rather than at prEnd() -- otherwise the stale
    # entry stays live for the whole time the file is being rewritten.
    if (!ref $utfil)
-   {  delete $processed{$utfil};
-      delete $behandlad{$utfil};
+   {  dropSourceCaches($utfil);
    }
    binmode UTFIL;
    my $utrad = "\%PDF-1.4\n\%\â\ã\Ï\Ó\n";
@@ -4454,6 +4453,47 @@ sub prep
 # way -- stat mtime is whole seconds -- so prInitVars() remains the reliable
 # reset when an external writer rewrites a source file in place.
 #
+# Everything cached about one source file, dropped together.
+#
+# %processed and %behandlad are keyed by the filename itself. %form, %intAct
+# and %image are keyed by a filename-derived prefix -- "$file_$page" and
+# "$file_$page_$image" -- so they need a scan rather than a lookup. %fontSource
+# is keyed by font name, but its foSOURCE value carries one of those prefixes
+# and is used to re-extract from the named file, so a stale entry there points
+# at bytes that no longer exist too.
+#
+# Called from prFile() at the moment the output file is truncated, which is a
+# document boundary: nothing is mid-emission, so entries that are consumed
+# while a document is being written cannot be pulled out from under it.
+sub dropSourceCaches
+{  my $fil = shift;
+   return if ref $fil;
+
+   delete $processed{$fil};
+   delete $behandlad{$fil};
+
+   my $prefix = $fil . '_';
+   for my $key (keys %form)
+   {  delete $form{$key} if index($key, $prefix) == 0;
+   }
+   for my $key (keys %intAct)
+   {  delete $intAct{$key} if index($key, $prefix) == 0;
+   }
+   for my $key (keys %image)
+   {  delete $image{$key} if index($key, $prefix) == 0;
+   }
+   for my $key (keys %knownToFile)
+   {  delete $knownToFile{$key}
+          if index($key, $prefix) == 0 || index($key, 'Ig:' . $prefix) == 0;
+   }
+   for my $font (keys %fontSource)
+   {  my $source = $fontSource{$font}[foSOURCE];
+      next unless defined $source;
+      delete $fontSource{$font} if index($source, $prefix) == 0;
+   }
+   return;
+}
+
 sub dropChangedCache
 {  my $infil = shift;
    return if ref $infil;

--- a/lib/PDF/Reuse.pm
+++ b/lib/PDF/Reuse.pm
@@ -4465,6 +4465,14 @@ sub prep
 # Called from prFile() at the moment the output file is truncated, which is a
 # document boundary: nothing is mid-emission, so entries that are consumed
 # while a document is being written cannot be pulled out from under it.
+#
+# The match is anchored on the page number rather than testing the filename as
+# a bare prefix, so rewriting "t.pdf" does not sweep entries belonging to
+# "t.pdf_backup". For %form and friends that would only cost a re-parse, but
+# dropping a %fontSource entry loses an embedded font: prFile() has already
+# cleared %font, so findFont() can no longer re-extract it and falls through
+# to a default face. \Q keeps filenames containing regex metacharacters
+# literal.
 sub dropSourceCaches
 {  my $fil = shift;
    return if ref $fil;
@@ -4472,24 +4480,25 @@ sub dropSourceCaches
    delete $processed{$fil};
    delete $behandlad{$fil};
 
-   my $prefix = $fil . '_';
+   my $owned = qr/\A\Q$fil\E_\d+(?:_|\z)/;
    for my $key (keys %form)
-   {  delete $form{$key} if index($key, $prefix) == 0;
+   {  delete $form{$key} if $key =~ $owned;
    }
    for my $key (keys %intAct)
-   {  delete $intAct{$key} if index($key, $prefix) == 0;
+   {  delete $intAct{$key} if $key =~ $owned;
    }
    for my $key (keys %image)
-   {  delete $image{$key} if index($key, $prefix) == 0;
+   {  delete $image{$key} if $key =~ $owned;
    }
    for my $key (keys %knownToFile)
-   {  delete $knownToFile{$key}
-          if index($key, $prefix) == 0 || index($key, 'Ig:' . $prefix) == 0;
+   {  my $bare = $key;
+      $bare =~ s/\AIg://;
+      delete $knownToFile{$key} if $bare =~ $owned;
    }
    for my $font (keys %fontSource)
    {  my $source = $fontSource{$font}[foSOURCE];
       next unless defined $source;
-      delete $fontSource{$font} if index($source, $prefix) == 0;
+      delete $fontSource{$font} if $source =~ $owned;
    }
    return;
 }

--- a/lib/PDF/Reuse.pm
+++ b/lib/PDF/Reuse.pm
@@ -4490,10 +4490,10 @@ sub dropSourceCaches
    for my $key (keys %image)
    {  delete $image{$key} if $key =~ $owned;
    }
+   my $owned_image = qr/\AIg:\Q$fil\E_\d+(?:_|\z)/;
    for my $key (keys %knownToFile)
-   {  my $bare = $key;
-      $bare =~ s/\AIg://;
-      delete $knownToFile{$key} if $bare =~ $owned;
+   {  delete $knownToFile{$key}
+          if $key =~ $owned || $key =~ $owned_image;
    }
    for my $font (keys %fontSource)
    {  my $source = $fontSource{$font}[foSOURCE];

--- a/t/regression.t
+++ b/t/regression.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 23;
+use Test::More tests => 26;
 use IO::String;
 use File::Temp qw(tempfile);
 use File::Spec;
@@ -390,4 +390,54 @@ SKIP: {
     };
     ok($kept >= 1,
         'GitHub #28: cache retained for a template that has not changed');
+}
+
+# Codex review of #32: the sweep originally tested the filename as a bare
+# prefix, so rewriting "t.pdf" also matched cache entries for "t.pdf_backup".
+# For %form that costs a re-parse; for %fontSource it loses an embedded font,
+# because prFile() has already cleared %font and findFont() can no longer
+# re-extract it. The match is anchored on the page number instead.
+{
+    my $dir  = File::Temp->newdir();
+    my $tpl  = File::Spec->catfile($dir, 't.pdf');
+    my $sib  = File::Spec->catfile($dir, 't.pdf_backup');
+
+    for my $f ($tpl, $sib) {
+        prFile($f);
+        prFontSize(24);
+        prText(72, 700, 'x');
+        prEnd();
+    }
+
+    # Seed both names into the caches by using each as a source.
+    for my $src ($tpl, $sib) {
+        prFile(File::Spec->catfile($dir, 'seed.pdf'));
+        prForm($src);
+        prEnd();
+    }
+
+    my $sib_before = do {
+        no strict 'refs';
+        scalar grep { index($_, $sib . '_') == 0 } keys %{"PDF::Reuse::form"};
+    };
+    ok($sib_before >= 1, 'GitHub #32: sibling filename is cached before the sweep')
+        or diag("sibling entries: $sib_before");
+
+    # Rewriting the shorter name must not disturb the longer one.
+    prFile($tpl);
+    prFontSize(24);
+    prText(72, 700, 'y');
+    prEnd();
+
+    my ($tpl_after, $sib_after) = do {
+        no strict 'refs';
+        my @k = keys %{"PDF::Reuse::form"};
+        ( scalar(grep { /\A\Q$tpl\E_\d+(?:_|\z)/ } @k),
+          scalar(grep { index($_, $sib . '_') == 0 } @k) );
+    };
+
+    is($tpl_after, 0,
+        'GitHub #32: the rewritten file\'s own entries are swept');
+    is($sib_after, $sib_before,
+        'GitHub #32: a sibling sharing the filename prefix is not swept');
 }

--- a/t/regression.t
+++ b/t/regression.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 19;
+use Test::More tests => 23;
 use IO::String;
 use File::Temp qw(tempfile);
 use File::Spec;
@@ -320,4 +320,74 @@ SKIP: {
         }
     }
     ok($consistent, 'GitHub #15: each bfchar section declares its true entry count');
+}
+
+# GitHub #28
+# %form, %intAct and %image are keyed by a filename-derived prefix and were not
+# cleared when the file behind that name was rewritten. That produced a
+# spurious mtime abort in byggForm(), and -- worse -- a stale cached BBox, so a
+# rewritten template silently kept its old page geometry.
+{
+    my $dir = File::Temp->newdir();
+    my $tpl = File::Spec->catfile($dir, 'tpl.pdf');
+
+    my $build = sub {
+        my ($label, $w, $h) = @_;
+        prFile($tpl);
+        prMbox(0, 0, $w, $h);
+        prFontSize(24);
+        prText(72, 100, $label);
+        prEnd();
+    };
+
+    my $consume = sub {
+        my ($out) = @_;
+        prFile(File::Spec->catfile($dir, $out));
+        prForm($tpl);
+        prEnd();
+        open my $fh, '<', File::Spec->catfile($dir, $out) or return '';
+        binmode $fh;
+        my $pdf = do { local $/; <$fh> };
+        close $fh;
+        return $pdf;
+    };
+
+    $build->('ALPHA', 595, 842);
+    $consume->('o1.pdf');
+
+    # Same filename, different page size.
+    $build->('BRAVO', 300, 300);
+    my $second = eval { $consume->('o2.pdf') };
+    ok(defined $second, 'GitHub #28: reusing a template filename does not abort')
+        or diag("Error: $@");
+
+    my ($bbox) = ($second // '') =~ m{/BBox\s*\[\s*([^\]]*?)\s*\]};
+    like($bbox // '', qr{\b300\s+300\b},
+        'GitHub #28: the rewritten page geometry is used, not the cached one')
+        or diag("BBox was: " . ($bbox // 'not found'));
+
+    unlike($bbox // '', qr{\b842\b},
+        'GitHub #28: the stale BBox is gone');
+
+    # The caches exist to make an unchanged template cheap to reuse; only the
+    # rewritten name may be swept.
+    my $fixed = File::Spec->catfile($dir, 'fixed.pdf');
+    prFile($fixed);
+    prFontSize(24);
+    prText(72, 700, 'unchanged');
+    prEnd();
+
+    prFile(File::Spec->catfile($dir, 'r1.pdf'));
+    prForm($fixed);
+    prEnd();
+    prFile(File::Spec->catfile($dir, 'r2.pdf'));
+    prForm($fixed);
+    prEnd();
+
+    my $kept = do {
+        no strict 'refs';
+        scalar grep { index($_, $fixed . '_') == 0 } keys %{"PDF::Reuse::form"};
+    };
+    ok($kept >= 1,
+        'GitHub #28: cache retained for a template that has not changed');
 }


### PR DESCRIPTION
Completes the invalidation work started in #26.

Ref #28

## The severity in the issue is understated — this is silent corruption

#28 assessed this as a *spurious abort*, on the evidence that a same-second rewrite still emitted the new content. **That holds for content and fails for geometry.**

`%form` caches `[fBBOX]`. A template rewritten at a different page size keeps the old one:

| | `/BBox` emitted |
|---|---|
| Reused filename | `0 0 595 842` ← stale, wrong |
| Distinct filename | `0 0 300 300` ← correct |

Same content, same operations, only the filename differs. The `byggForm()` mtime abort was the *visible half* of a bug whose quiet half produces wrong page geometry with no warning at all.

**That rules out option 3** from the issue (relax the abort) — it would have removed the warning and left the corruption in place.

## The fix

Swept in `prFile()` at the moment the output file is truncated — where #26 already invalidates, and a document boundary, so nothing is mid-emission. That was precisely why this couldn't be folded into #26's `dropChangedCache`, which runs at seven cache-fill sites that fire mid-document.

Caches swept for the rewritten name:

| Cache | Key | Why |
|---|---|---|
| `%processed`, `%behandlad` | `$file` | already handled by #26 |
| `%form`, `%intAct` | `"$file_$page"` | prefix scan |
| `%image` | `"$file_$page_$image"` | prefix scan |
| `%knownToFile` | same, plus `Ig:` variants | prefix scan |
| `%fontSource` | font name, but `foSOURCE` **carries** a prefix and re-extracts from the named file | value scan |

`%fontSource` wasn't in the issue's list — worth flagging, since a stale entry there points at bytes that no longer exist.

Compound keys need a scan rather than a lookup. These hashes hold one entry per source page, so the cost is negligible next to parsing a PDF.

## Verification

Both failures reproduced on master **first**, then confirmed fixed:

```
before:  pass2 DIED: 1785344198 ne 1785344196 aborts
after:   pass2 ok

before:  /BBox [0 0 595 842]   (file was rewritten as 300x300)
after:   /BBox [0 0 300 300]
```

The caches still survive for an unchanged template reused across four documents — that's what they exist for, and only the rewritten name is swept.

**37 tests**, up from 33. Two of the four new assertions fail against the unmodified module.

## Deliberately not done

The `analysera()`/`findGet()` ordering noted at the end of #28. It's a separate pre-existing inconsistency on the `prCid` replay path and doesn't belong in a cache-invalidation change.

**Load-bearing: yes.** Changes cache lifetime for five package hashes read throughout the module. Worth reviewer attention on the prefix-matching: `index($key, $prefix) == 0` is a literal prefix test, so a filename containing regex metacharacters is safe, but a file named `t.pdf` and another named `t.pdf_backup` would share a prefix — I judged that acceptable since the second would have to be used as a source template in the same session, but flag it if you disagree.
